### PR TITLE
Fix prompt service usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,19 @@ curl -X POST http://localhost:8000/api/v1/twitch/{integration_id}/monitor \
   -d '{"streamer": "your_favorite_streamer"}'
 ```
 
+#### Custom Prompts
+```bash
+# Create a prompt
+curl -X POST http://localhost:8000/api/v1/prompts?user_id=123 \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"My Prompt","prompt":"Find highlights","category":"GENERAL"}'
+
+# Increment prompt usage
+curl -X POST http://localhost:8000/api/v1/prompts/{prompt_id}/use?user_id=123 \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
 ### 🖥️ Command Line Tools
 
 ```bash

--- a/backend/app/api/endpoints/prompts.py
+++ b/backend/app/api/endpoints/prompts.py
@@ -14,20 +14,23 @@ router = APIRouter()
 
 @router.get("/", response_model=List[CustomPrompt])
 async def get_prompts(
+    user_id: int,
     skip: int = 0,
     limit: int = 100,
     category: Optional[PromptCategory] = None,
     db: Database = Depends(get_db)
 ):
     """Get custom prompts"""
-    prompt_service = PromptService(db)
-    return await prompt_service.get_prompts(skip=skip, limit=limit, category=category)
+    prompt_service = PromptService()
+    return await prompt_service.get_prompts(
+        user_id=user_id, skip=skip, limit=limit, category=category
+    )
 
 @router.get("/{prompt_id}", response_model=CustomPrompt)
-async def get_prompt(prompt_id: str, db: Database = Depends(get_db)):
+async def get_prompt(prompt_id: str, user_id: int, db: Database = Depends(get_db)):
     """Get prompt by ID"""
-    prompt_service = PromptService(db)
-    prompt = await prompt_service.get_prompt(prompt_id)
+    prompt_service = PromptService()
+    prompt = await prompt_service.get_prompt(prompt_id, user_id)
     if not prompt:
         raise HTTPException(status_code=404, detail="Prompt not found")
     return prompt
@@ -35,38 +38,40 @@ async def get_prompt(prompt_id: str, db: Database = Depends(get_db)):
 @router.post("/", response_model=CustomPrompt)
 async def create_prompt(
     prompt_data: CustomPromptCreate,
+    user_id: int,
     db: Database = Depends(get_db)
 ):
     """Create a new custom prompt"""
-    prompt_service = PromptService(db)
-    return await prompt_service.create_prompt(prompt_data)
+    prompt_service = PromptService()
+    return await prompt_service.create_prompt(prompt_data, user_id)
 
 @router.put("/{prompt_id}", response_model=CustomPrompt)
 async def update_prompt(
     prompt_id: str,
     prompt_update: CustomPromptUpdate,
+    user_id: int,
     db: Database = Depends(get_db)
 ):
     """Update custom prompt"""
-    prompt_service = PromptService(db)
-    prompt = await prompt_service.update_prompt(prompt_id, prompt_update)
+    prompt_service = PromptService()
+    prompt = await prompt_service.update_prompt(prompt_id, prompt_update, user_id)
     if not prompt:
         raise HTTPException(status_code=404, detail="Prompt not found")
     return prompt
 
 @router.delete("/{prompt_id}")
-async def delete_prompt(prompt_id: str, db: Database = Depends(get_db)):
+async def delete_prompt(prompt_id: str, user_id: int, db: Database = Depends(get_db)):
     """Delete custom prompt"""
-    prompt_service = PromptService(db)
-    await prompt_service.delete_prompt(prompt_id)
+    prompt_service = PromptService()
+    await prompt_service.delete_prompt(prompt_id, user_id)
     return {"message": "Prompt deleted successfully"}
 
 @router.post("/{prompt_id}/use")
-async def use_prompt(prompt_id: str, db: Database = Depends(get_db)):
-    """Mark prompt as used (increment use count)"""
-    prompt_service = PromptService(db)
-    prompt = await prompt_service.use_prompt(prompt_id)
-    if not prompt:
+async def use_prompt(prompt_id: str, user_id: int, db: Database = Depends(get_db)):
+    """Increment the usage count for a prompt"""
+    prompt_service = PromptService()
+    success = await prompt_service.increment_use_count(prompt_id, user_id)
+    if not success:
         raise HTTPException(status_code=404, detail="Prompt not found")
     return {"message": "Prompt usage recorded"}
 


### PR DESCRIPTION
## Summary
- update prompt endpoints to instantiate `PromptService` without arguments
- pass `user_id` into service methods and use `increment_use_count`
- document prompt API usage in README

## Testing
- `pytest -q`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6854f65f64e08326bae3338171db975e