### PR TITLE
Add basic tests and pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,15 @@ We welcome contributions from the community! Here's how you can help make ClipMa
 - **📋 Commit Messages** - Use conventional commit format
 - **🔍 Code Review** - All PRs require review
 
+### 🧪 Running Tests
+
+Install the backend requirements and run `pytest` from the project root:
+
+```bash
+pip install -r backend/requirements.txt  # or install your dev environment
+pytest
+```
+
 ### 🐛 Bug Reports
 
 Found a bug? Please create an issue with:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.endpoints.system import router as system_router
+
+app = FastAPI()
+app.include_router(system_router, prefix="/api/v1/system")
+
+@pytest.fixture
+def client(monkeypatch):
+    with TestClient(app) as client:
+        yield client
+
+
+def test_system_health_endpoint(client, monkeypatch):
+    async def fake_health(self):
+        return {"disk_usage": 10, "memory_usage": 20, "recommendations": [], "directory_usage": {}}
+    monkeypatch.setattr("app.services.system_service.SystemService.check_storage_usage", fake_health)
+    response = client.get("/api/v1/system/health")
+    assert response.status_code == 200
+    assert response.json()["disk_usage"] == 10

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+
+from app.services.system_service import SystemService
+from app.core import config
+
+@pytest.mark.asyncio
+async def test_cleanup_temp_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(config.settings, "TEMP_DIR", str(tmp_path))
+    # create temporary files
+    file1 = tmp_path / "a.txt"
+    file1.write_bytes(b"12345")
+    file2 = tmp_path / "b.txt"
+    file2.write_bytes(b"hi")
+
+    service = SystemService()
+    result = await service.cleanup_temp_files()
+    assert result["cleaned"] == 2
+    assert result["size_freed"] >= 7
+    assert not file1.exists() and not file2.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["backend"]
+testpaths = ["backend/tests"]


### PR DESCRIPTION
## Summary
- configure pytest via `pyproject.toml`
- add service and API tests under `backend/tests`
- document how to run the tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685516d3dd8c832681db3ba30db430ab