### PR TITLE
Implement Twitch OAuth token exchange

### DIFF
--- a/backend/app/api/endpoints/twitch.py
+++ b/backend/app/api/endpoints/twitch.py
@@ -1,22 +1,28 @@
-
 """
 Twitch integration endpoints
 """
+
 from typing import List, Optional
-from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
-from databases import Database
 
 from app.core.database import get_db
-from app.models.twitch import TwitchIntegration, TwitchIntegrationCreate, TwitchIntegrationUpdate
+from app.models.twitch import (
+    TwitchIntegration,
+    TwitchIntegrationCreate,
+    TwitchIntegrationUpdate,
+)
 from app.services.twitch_service import TwitchService
+from databases import Database
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 router = APIRouter()
+
 
 @router.get("/", response_model=List[TwitchIntegration])
 async def get_integrations(db: Database = Depends(get_db)):
     """Get Twitch integrations"""
     twitch_service = TwitchService(db)
     return await twitch_service.get_integrations()
+
 
 @router.get("/{integration_id}", response_model=TwitchIntegration)
 async def get_integration(integration_id: str, db: Database = Depends(get_db)):
@@ -27,27 +33,31 @@ async def get_integration(integration_id: str, db: Database = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Integration not found")
     return integration
 
+
 @router.post("/", response_model=TwitchIntegration)
 async def create_integration(
-    integration_data: TwitchIntegrationCreate,
-    db: Database = Depends(get_db)
+    integration_data: TwitchIntegrationCreate, db: Database = Depends(get_db)
 ):
     """Create Twitch integration"""
     twitch_service = TwitchService(db)
     return await twitch_service.create_integration(integration_data)
 
+
 @router.put("/{integration_id}", response_model=TwitchIntegration)
 async def update_integration(
     integration_id: str,
     integration_update: TwitchIntegrationUpdate,
-    db: Database = Depends(get_db)
+    db: Database = Depends(get_db),
 ):
     """Update Twitch integration"""
     twitch_service = TwitchService(db)
-    integration = await twitch_service.update_integration(integration_id, integration_update)
+    integration = await twitch_service.update_integration(
+        integration_id, integration_update
+    )
     if not integration:
         raise HTTPException(status_code=404, detail="Integration not found")
     return integration
+
 
 @router.delete("/{integration_id}")
 async def delete_integration(integration_id: str, db: Database = Depends(get_db)):
@@ -56,38 +66,39 @@ async def delete_integration(integration_id: str, db: Database = Depends(get_db)
     await twitch_service.delete_integration(integration_id)
     return {"message": "Integration deleted successfully"}
 
+
 @router.post("/{integration_id}/start-monitoring")
 async def start_monitoring(
     integration_id: str,
     background_tasks: BackgroundTasks,
-    db: Database = Depends(get_db)
+    db: Database = Depends(get_db),
 ):
     """Start monitoring Twitch stream"""
     twitch_service = TwitchService(db)
     integration = await twitch_service.get_integration(integration_id)
     if not integration:
         raise HTTPException(status_code=404, detail="Integration not found")
-    
+
     # Start background monitoring
     background_tasks.add_task(monitor_stream_async, integration_id, db)
-    
+
     # Update integration status
     await twitch_service.update_integration(
-        integration_id,
-        TwitchIntegrationUpdate(is_monitoring=True)
+        integration_id, TwitchIntegrationUpdate(is_monitoring=True)
     )
-    
+
     return {"message": "Stream monitoring started"}
+
 
 @router.post("/{integration_id}/stop-monitoring")
 async def stop_monitoring(integration_id: str, db: Database = Depends(get_db)):
     """Stop monitoring Twitch stream"""
     twitch_service = TwitchService(db)
     await twitch_service.update_integration(
-        integration_id,
-        TwitchIntegrationUpdate(is_monitoring=False)
+        integration_id, TwitchIntegrationUpdate(is_monitoring=False)
     )
     return {"message": "Stream monitoring stopped"}
+
 
 @router.get("/{integration_id}/status")
 async def get_stream_status(integration_id: str, db: Database = Depends(get_db)):
@@ -96,29 +107,31 @@ async def get_stream_status(integration_id: str, db: Database = Depends(get_db))
     integration = await twitch_service.get_integration(integration_id)
     if not integration:
         raise HTTPException(status_code=404, detail="Integration not found")
-    
+
     # Get live stream info
     stream_info = await twitch_service.get_stream_info(integration.user_id)
     return stream_info
 
-@router.post("/auth/callback")
+
+@router.post("/auth/callback", response_model=TwitchIntegration)
 async def twitch_auth_callback(
-    code: str,
-    state: Optional[str] = None,
-    db: Database = Depends(get_db)
+    code: str, state: Optional[str] = None, db: Database = Depends(get_db)
 ):
     """Handle Twitch OAuth callback"""
     twitch_service = TwitchService(db)
     integration = await twitch_service.handle_auth_callback(code, state)
-    return {"message": "Authentication successful", "integration_id": integration.id}
+    return integration
+
 
 async def monitor_stream_async(integration_id: str, db: Database):
     """Background task for stream monitoring"""
     try:
         from app.services.stream_monitor import StreamMonitor
+
         monitor = StreamMonitor(db)
         await monitor.start_monitoring(integration_id)
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.error(f"Stream monitoring error: {e}")

--- a/backend/app/models/twitch.py
+++ b/backend/app/models/twitch.py
@@ -1,10 +1,12 @@
-
 """
 Twitch integration models
 """
-from typing import Optional
-from pydantic import BaseModel
+
 from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
 
 class TwitchIntegrationBase(BaseModel):
     username: str
@@ -13,9 +15,11 @@ class TwitchIntegrationBase(BaseModel):
     auto_capture: bool = False
     chat_monitoring: bool = True
 
+
 class TwitchIntegrationCreate(TwitchIntegrationBase):
     access_token: str
     refresh_token: str
+
 
 class TwitchIntegrationUpdate(BaseModel):
     is_monitoring: Optional[bool] = None
@@ -26,8 +30,11 @@ class TwitchIntegrationUpdate(BaseModel):
     last_stream_game: Optional[str] = None
     last_used_at: Optional[datetime] = None
 
+
 class TwitchIntegration(TwitchIntegrationBase):
     id: str
+    access_token: Optional[str] = Field(default=None, exclude=True)
+    refresh_token: Optional[str] = Field(default=None, exclude=True)
     last_stream_id: Optional[str] = None
     last_stream_title: Optional[str] = None
     last_stream_game: Optional[str] = None

--- a/backend/app/services/twitch_service.py
+++ b/backend/app/services/twitch_service.py
@@ -1,23 +1,51 @@
-
 """
 Twitch service for integration management
 """
+
+import base64
+import hashlib
+import logging
 import uuid
-from typing import List, Optional, Dict, Any
 from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional
+
+from app.core.config import settings
+from app.models.twitch import (
+    TwitchIntegration,
+    TwitchIntegrationCreate,
+    TwitchIntegrationUpdate,
+)
+from app.twitch.client import TwitchAPIClient
+from cryptography.fernet import Fernet
 from databases import Database
 
-from app.models.twitch import TwitchIntegration, TwitchIntegrationCreate, TwitchIntegrationUpdate
-from app.core.config import settings
-import logging
-
 logger = logging.getLogger(__name__)
+
 
 class TwitchService:
     def __init__(self, db: Database):
         self.db = db
+        key = hashlib.sha256(settings.SECRET_KEY.encode()).digest()
+        self._fernet = Fernet(base64.urlsafe_b64encode(key))
+        self.twitch_client = TwitchAPIClient()
 
-    async def create_integration(self, integration_data: TwitchIntegrationCreate) -> TwitchIntegration:
+    def _encrypt(self, token: str) -> str:
+        return self._fernet.encrypt(token.encode()).decode()
+
+    def _decrypt(self, token: str) -> str:
+        return self._fernet.decrypt(token.encode()).decode()
+
+    def _decrypt_row(self, row: Mapping[str, Any]) -> Dict[str, Any]:
+        data = dict(row)
+        if "access_token" in data and data["access_token"]:
+            data["access_token"] = self._decrypt(data["access_token"])
+        if "refresh_token" in data and data["refresh_token"]:
+            data["refresh_token"] = self._decrypt(data["refresh_token"])
+        return data
+
+    async def create_integration(
+        self, integration_data: TwitchIntegrationCreate
+    ) -> TwitchIntegration:
         """Create a new Twitch integration"""
         query = """
         INSERT INTO twitch_integrations (id, access_token, refresh_token, username, user_id,
@@ -27,87 +55,85 @@ class TwitchService:
                 :is_monitoring, :auto_capture, :chat_monitoring, :connected_at, :last_used_at)
         RETURNING *
         """
-        
+
         integration_id = str(uuid.uuid4())
         now = datetime.utcnow()
-        
+
         values = {
             "id": integration_id,
-            "access_token": integration_data.access_token,
-            "refresh_token": integration_data.refresh_token,
+            "access_token": self._encrypt(integration_data.access_token),
+            "refresh_token": self._encrypt(integration_data.refresh_token),
             "username": integration_data.username,
             "user_id": integration_data.user_id,
             "is_monitoring": integration_data.is_monitoring,
             "auto_capture": integration_data.auto_capture,
             "chat_monitoring": integration_data.chat_monitoring,
             "connected_at": now,
-            "last_used_at": now
+            "last_used_at": now,
         }
-        
+
         result = await self.db.fetch_one(query, values)
-        return TwitchIntegration(**result) if result else None
+        return TwitchIntegration(**self._decrypt_row(result)) if result else None
 
     async def get_integration(self, integration_id: str) -> Optional[TwitchIntegration]:
         """Get integration by ID"""
         query = "SELECT * FROM twitch_integrations WHERE id = :integration_id"
         result = await self.db.fetch_one(query, {"integration_id": integration_id})
-        return TwitchIntegration(**result) if result else None
+        return TwitchIntegration(**self._decrypt_row(result)) if result else None
 
     async def get_integrations(self) -> List[TwitchIntegration]:
         """Get all integrations"""
         query = "SELECT * FROM twitch_integrations ORDER BY connected_at DESC"
         results = await self.db.fetch_all(query)
-        return [TwitchIntegration(**result) for result in results]
+        return [TwitchIntegration(**self._decrypt_row(result)) for result in results]
 
     async def update_integration(
-        self, 
-        integration_id: str, 
-        integration_update: TwitchIntegrationUpdate
+        self, integration_id: str, integration_update: TwitchIntegrationUpdate
     ) -> Optional[TwitchIntegration]:
         """Update integration"""
         set_clauses = []
         values = {"integration_id": integration_id}
-        
+
         if integration_update.is_monitoring is not None:
             set_clauses.append("is_monitoring = :is_monitoring")
             values["is_monitoring"] = integration_update.is_monitoring
-            
+
         if integration_update.auto_capture is not None:
             set_clauses.append("auto_capture = :auto_capture")
             values["auto_capture"] = integration_update.auto_capture
-            
+
         if integration_update.chat_monitoring is not None:
             set_clauses.append("chat_monitoring = :chat_monitoring")
             values["chat_monitoring"] = integration_update.chat_monitoring
-            
+
         if integration_update.last_stream_id is not None:
             set_clauses.append("last_stream_id = :last_stream_id")
             values["last_stream_id"] = integration_update.last_stream_id
-            
+
         if integration_update.last_stream_title is not None:
             set_clauses.append("last_stream_title = :last_stream_title")
             values["last_stream_title"] = integration_update.last_stream_title
-            
+
         if integration_update.last_stream_game is not None:
             set_clauses.append("last_stream_game = :last_stream_game")
             values["last_stream_game"] = integration_update.last_stream_game
-            
+
         if integration_update.last_used_at is not None:
             set_clauses.append("last_used_at = :last_used_at")
             values["last_used_at"] = integration_update.last_used_at
-        
+
         if not set_clauses:
             return await self.get_integration(integration_id)
-        
+
         query = f"""
         UPDATE twitch_integrations 
         SET {', '.join(set_clauses)}
         WHERE id = :integration_id
         RETURNING *
         """
-        
+
         result = await self.db.fetch_one(query, values)
-        return TwitchIntegration(**result) if result else None
+        return TwitchIntegration(**self._decrypt_row(result)) if result else None
 
     async def delete_integration(self, integration_id: str) -> bool:
         """Delete integration"""
@@ -117,36 +143,51 @@ class TwitchService:
 
     async def get_stream_info(self, user_id: str) -> Dict[str, Any]:
         """Get current stream information"""
-        # This would integrate with Twitch API
-        # For now, return mock data
-        return {
-            "is_live": False,
-            "stream_title": None,
-            "game_name": None,
-            "viewer_count": 0,
-            "started_at": None
-        }
+        try:
+            return await self.twitch_client.get_stream_info(user_id)
+        except Exception as exc:
+            logger.error(f"Failed to fetch stream info: {exc}")
+            return {"is_live": False, "error": str(exc)}
 
-    async def handle_auth_callback(self, code: str, state: Optional[str] = None) -> TwitchIntegration:
+    async def handle_auth_callback(
+        self, code: str, state: Optional[str] = None
+    ) -> TwitchIntegration:
         """Handle Twitch OAuth callback"""
-        # This would exchange the code for access tokens
-        # For now, create a mock integration
+        token_data = await self.twitch_client.exchange_code_for_token(code)
+        user_info = await self.twitch_client.get_user_info(token_data["access_token"])
         integration_data = TwitchIntegrationCreate(
-            access_token="mock_access_token",
-            refresh_token="mock_refresh_token",
-            username="mock_user",
-            user_id="mock_user_id"
+            access_token=token_data["access_token"],
+            refresh_token=token_data["refresh_token"],
+            username=user_info["login"],
+            user_id=user_info["id"],
         )
         return await self.create_integration(integration_data)
 
     async def refresh_token(self, integration_id: str) -> bool:
         """Refresh access token"""
-        # This would refresh the access token using the refresh token
-        logger.info(f"Refreshing token for integration {integration_id}")
+        query = "SELECT refresh_token FROM twitch_integrations WHERE id = :id"
+        row = await self.db.fetch_one(query, {"id": integration_id})
+        if not row:
+            return False
+        refresh_token = self._decrypt(row["refresh_token"])
+        tokens = await self.twitch_client.refresh_access_token(refresh_token)
+        update_query = (
+            "UPDATE twitch_integrations SET access_token=:access, refresh_token=:refresh, last_used_at=:used"
+            " WHERE id=:id"
+        )
+        await self.db.execute(
+            update_query,
+            {
+                "access": self._encrypt(tokens["access_token"]),
+                "refresh": self._encrypt(tokens["refresh_token"]),
+                "used": datetime.utcnow(),
+                "id": integration_id,
+            },
+        )
         return True
 
     async def get_user_by_username(self, username: str) -> Optional[TwitchIntegration]:
         """Get integration by username"""
         query = "SELECT * FROM twitch_integrations WHERE username = :username"
         result = await self.db.fetch_one(query, {"username": username})
-        return TwitchIntegration(**result) if result else None
+        return TwitchIntegration(**self._decrypt_row(result)) if result else None


### PR DESCRIPTION
## Summary
- encrypt Twitch tokens using Fernet
- integrate Twitch OAuth exchange and token refresh
- return `TwitchIntegration` from OAuth callback
- expose tokens internally but hide from API output

## Testing
- `black backend/app/models/twitch.py backend/app/services/twitch_service.py backend/app/api/endpoints/twitch.py`
- `isort backend/app/models/twitch.py backend/app/services/twitch_service.py backend/app/api/endpoints/twitch.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855823cc87083269142d20d9ebe6b81