### PR TITLE
Add Twitch integration tests

### DIFF
--- a/backend/tests/test_stream_monitor.py
+++ b/backend/tests/test_stream_monitor.py
@@ -1,0 +1,71 @@
+import asyncio
+from datetime import datetime
+import pytest
+
+from app.twitch.stream_monitor import StreamMonitor
+from app.models.twitch import TwitchIntegration
+from app.twitch.client import TwitchAPIClient
+from app.services import twitch_service
+
+
+class DummyService:
+    def __init__(self, db):
+        self.db = db
+        self.updated = []
+
+    async def get_integration(self, integration_id: str) -> TwitchIntegration:
+        return TwitchIntegration(
+            id=integration_id,
+            username="tester",
+            user_id="user123",
+            access_token="",  # not used
+            refresh_token="",
+            is_monitoring=False,
+            auto_capture=False,
+            chat_monitoring=False,
+            last_stream_id=None,
+            last_stream_title=None,
+            last_stream_game=None,
+            connected_at=datetime.utcnow(),
+            last_used_at=datetime.utcnow(),
+        )
+
+    async def update_integration(self, integration_id: str, data):
+        self.updated.append((integration_id, data))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_monitoring_loop_updates_db(monkeypatch):
+    service = DummyService(None)
+    monkeypatch.setattr(twitch_service, "TwitchService", lambda db: service)
+
+    async def fake_stream_info(self, user_id):
+        return {
+            "is_live": True,
+            "stream_id": "abc",
+            "title": "Hello",
+            "game_name": "Game",
+            "viewer_count": 10,
+        }
+
+    monkeypatch.setattr(TwitchAPIClient, "get_stream_info", fake_stream_info)
+
+    monitor = StreamMonitor("integration1", db=None)
+
+    async def fake_sleep(seconds):
+        monitor.is_monitoring = False
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(StreamMonitor, "_check_highlight_triggers", lambda self: asyncio.sleep(0))
+
+    monitor.is_monitoring = True
+    integration = await service.get_integration("integration1")
+    await monitor._monitoring_loop(integration, auto_capture=False)
+
+    assert service.updated
+    upd = service.updated[0][1]
+    assert upd["last_stream_id"] == "abc"
+    assert upd["last_stream_title"] == "Hello"
+    assert upd["last_stream_game"] == "Game"

--- a/backend/tests/test_twitch_oauth.py
+++ b/backend/tests/test_twitch_oauth.py
@@ -1,0 +1,74 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from datetime import datetime
+
+from app.api.endpoints.twitch import router, get_db
+from app.services.twitch_service import TwitchService
+from app.twitch.client import TwitchAPIClient
+from app.models.twitch import TwitchIntegration, TwitchIntegrationCreate
+
+class DummyDB:
+    pass
+
+@pytest.fixture
+def app_client(monkeypatch):
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/twitch")
+
+    async def override_get_db():
+        yield DummyDB()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    # Mock Twitch API client methods
+    async def fake_exchange(self, code):
+        assert code == "testcode"
+        return {"access_token": "AA", "refresh_token": "RR"}
+
+    async def fake_user_info(self, token):
+        assert token == "AA"
+        return {"id": "user123", "login": "tester"}
+
+    monkeypatch.setattr(TwitchAPIClient, "exchange_code_for_token", fake_exchange)
+    monkeypatch.setattr(TwitchAPIClient, "get_user_info", fake_user_info)
+
+    created = {}
+
+    async def fake_create(self, data: TwitchIntegrationCreate):
+        created.update(data.dict())
+        return TwitchIntegration(
+            id="integration1",
+            username=data.username,
+            user_id=data.user_id,
+            access_token=data.access_token,
+            refresh_token=data.refresh_token,
+            is_monitoring=data.is_monitoring,
+            auto_capture=data.auto_capture,
+            chat_monitoring=data.chat_monitoring,
+            last_stream_id=None,
+            last_stream_title=None,
+            last_stream_game=None,
+            connected_at=datetime.utcnow(),
+            last_used_at=datetime.utcnow(),
+        )
+
+    def fake_init(self, db):
+        self.db = db
+        self.twitch_client = TwitchAPIClient()
+
+    monkeypatch.setattr(TwitchService, "__init__", fake_init)
+    monkeypatch.setattr(TwitchService, "create_integration", fake_create)
+
+    with TestClient(app) as client:
+        yield client, created
+
+
+def test_oauth_callback_creates_integration(app_client):
+    client, created = app_client
+    response = client.post("/api/v1/twitch/auth/callback?code=testcode")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "tester"
+    assert created["username"] == "tester"
+    assert created["access_token"] == "AA"


### PR DESCRIPTION
## Summary
- add OAuth callback test that mocks Twitch API responses
- add stream monitor test for integration update logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6855e52471588326a23b643a2082dbb8