### PR TITLE
Remove node_modules symlink and document install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@
 git clone https://github.com/KenB-Good/ClipMaster.git
 cd ClipMaster
 
+# Install front-end dependencies
+(cd app && npm install) # or use `yarn install`
+
 # 🔧 Run automated installation
 chmod +x scripts/install.sh
 ./scripts/install.sh

--- a/app/node_modules
+++ b/app/node_modules
@@ -1,1 +1,0 @@
-/opt/hostedapp/node/root/app/node_modules


### PR DESCRIPTION
## Summary
- remove the tracked `app/node_modules` symlink
- mention running `npm install` in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6859b950aee88326999d0ff83f5ea3e1