### PR TITLE
Add service tests with mocks

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,90 @@
+import os
+import tempfile
+import pytest
+import pytest_asyncio
+from databases import Database
+
+@pytest.fixture(autouse=True, scope="session")
+def set_env():
+    os.environ.setdefault("SECRET_KEY", "testsecret")
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    db_path = tmp_path / "test.db"
+    database = Database(f"sqlite+aiosqlite:///{db_path}")
+    await database.connect()
+    # videos table
+    await database.execute(
+        """
+        CREATE TABLE videos(
+            id TEXT PRIMARY KEY,
+            filename TEXT,
+            original_filename TEXT,
+            file_path TEXT,
+            file_size INTEGER,
+            format TEXT,
+            resolution TEXT,
+            source TEXT,
+            twitch_stream_id TEXT,
+            twitch_title TEXT,
+            twitch_game TEXT,
+            uploaded_at TEXT,
+            processed_at TEXT,
+            status TEXT,
+            transcription TEXT
+        )
+        """
+    )
+    await database.execute(
+        """
+        CREATE TABLE highlights(
+            id TEXT PRIMARY KEY,
+            video_id TEXT,
+            start_time REAL,
+            end_time REAL,
+            confidence REAL,
+            type TEXT,
+            description TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    await database.execute(
+        """
+        CREATE TABLE clips(
+            id TEXT PRIMARY KEY,
+            video_id TEXT,
+            highlight_id TEXT,
+            filename TEXT,
+            file_path TEXT,
+            file_size INTEGER,
+            duration REAL,
+            start_time REAL,
+            end_time REAL,
+            format TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    await database.execute(
+        """
+        CREATE TABLE twitch_integrations(
+            id TEXT PRIMARY KEY,
+            access_token TEXT,
+            refresh_token TEXT,
+            username TEXT,
+            user_id TEXT,
+            is_monitoring BOOLEAN,
+            auto_capture BOOLEAN,
+            chat_monitoring BOOLEAN,
+            last_stream_id TEXT,
+            last_stream_title TEXT,
+            last_stream_game TEXT,
+            connected_at TEXT,
+            last_used_at TEXT
+        )
+        """
+    )
+    yield database
+    await database.disconnect()
+

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -1,0 +1,78 @@
+import sys
+import types
+import pytest
+from datetime import datetime
+
+# Provide dummy heavy modules before importing ai_service
+sys.modules.setdefault(
+    "torch",
+    types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False)),
+)
+sys.modules.setdefault(
+    "whisper",
+    types.SimpleNamespace(load_model=lambda *a, **k: types.SimpleNamespace(transcribe=lambda p: {"text": "dummy"})),
+)
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+from app.services import ai_service
+from app.models.video import Video, VideoUpdate, VideoStatus, VideoSource
+
+class DummyVideoService:
+    def __init__(self, db):
+        self.store = db
+    async def get_video(self, vid):
+        return self.store.get(vid)
+    async def update_video(self, vid, update: VideoUpdate):
+        video = self.store.get(vid)
+        if not video:
+            return None
+        data = update.model_dump(exclude_unset=True)
+        for k, v in data.items():
+            setattr(video, k, v)
+        return video
+
+class DummyTaskService:
+    def __init__(self, db):
+        self.updates = []
+    async def update_task(self, tid, update):
+        self.updates.append((tid, update))
+        return None
+
+@pytest.fixture
+def monkeypatched_ai(monkeypatch):
+    monkeypatch.setattr(ai_service, "VideoService", DummyVideoService)
+    monkeypatch.setattr(ai_service, "TaskService", DummyTaskService)
+    async def fake_load(self):
+        self.whisper_model = types.SimpleNamespace(transcribe=lambda p: {"text": "hello"})
+    monkeypatch.setattr(ai_service.AIService, "load_whisper_model", fake_load)
+    async def fake_extract(self, p):
+        return p
+    monkeypatch.setattr(ai_service.AIService, "_extract_audio", fake_extract)
+    return ai_service.AIService()
+
+@pytest.mark.asyncio
+async def test_transcribe_success(monkeypatched_ai):
+    store = {
+        "v1": Video(
+            id="v1",
+            filename="f.mp4",
+            original_filename="f.mp4",
+            file_size=1,
+            format="mp4",
+            resolution="720p",
+            source=VideoSource.UPLOAD,
+            file_path="/tmp/f.mp4",
+            status=VideoStatus.UPLOADED,
+            uploaded_at=datetime.utcnow(),
+        )
+    }
+    result = await monkeypatched_ai.transcribe_video("v1", "t1", store)
+    assert result == "hello"
+
+@pytest.mark.asyncio
+async def test_transcribe_missing_video(monkeypatched_ai):
+    store = {}
+    res = await monkeypatched_ai.transcribe_video("missing", "t2", store)
+    assert res is None
+
+

--- a/backend/tests/test_twitch_service.py
+++ b/backend/tests/test_twitch_service.py
@@ -1,0 +1,36 @@
+import pytest
+from datetime import datetime
+from app.services import twitch_service
+from app.models.twitch import TwitchIntegrationCreate
+
+class DummyClient:
+    def __init__(self):
+        self.refreshed = []
+    async def refresh_access_token(self, token):
+        self.refreshed.append(token)
+        return {"access_token": "newA", "refresh_token": "newR"}
+
+@pytest.fixture
+def service(monkeypatch, db):
+    monkeypatch.setattr(twitch_service, "TwitchAPIClient", DummyClient)
+    return twitch_service.TwitchService(db)
+
+@pytest.mark.asyncio
+async def test_create_and_get(service):
+    data = TwitchIntegrationCreate(access_token="aa", refresh_token="rr", username="u", user_id="1")
+    integ = await service.create_integration(data)
+    assert integ.username == "u"
+    fetched = await service.get_integration(integ.id)
+    assert fetched.username == "u"
+
+@pytest.mark.asyncio
+async def test_refresh_token(service):
+    data = TwitchIntegrationCreate(access_token="a", refresh_token="r", username="u2", user_id="2")
+    integ = await service.create_integration(data)
+    ok = await service.refresh_token(integ.id)
+    assert ok
+
+@pytest.mark.asyncio
+async def test_refresh_token_missing(service):
+    assert await service.refresh_token("missing") is False
+

--- a/backend/tests/test_video_service.py
+++ b/backend/tests/test_video_service.py
@@ -1,0 +1,49 @@
+import pytest
+from datetime import datetime
+from app.services.video_service import VideoService
+from app.models.video import VideoCreate, VideoUpdate, VideoStatus, VideoSource
+
+@pytest.mark.asyncio
+async def test_video_crud_flow(db):
+    service = VideoService(db)
+    data = VideoCreate(
+        filename="test.mp4",
+        original_filename="orig.mp4",
+        file_size=100,
+        format="mp4",
+        resolution="720p",
+        source=VideoSource.UPLOAD,
+    )
+    video = await service.create_video(data, "/tmp/test.mp4")
+    assert video.filename == "test.mp4"
+
+    fetched = await service.get_video(video.id)
+    assert fetched is not None and fetched.id == video.id
+
+
+    updated = await service.update_video(video.id, VideoUpdate(status=VideoStatus.PROCESSED))
+    assert updated.status == VideoStatus.PROCESSED
+
+    await service.delete_video(video.id)
+    assert await service.get_video(video.id) is None
+
+@pytest.mark.asyncio
+async def test_update_no_fields(db):
+    service = VideoService(db)
+    data = VideoCreate(
+        filename="a.mp4",
+        original_filename="a.mp4",
+        file_size=1,
+        format="mp4",
+        resolution=None,
+        source=VideoSource.UPLOAD,
+    )
+    video = await service.create_video(data, "/tmp/a.mp4")
+    # Updating with no fields should return original
+    res = await service.update_video(video.id, VideoUpdate())
+    assert res.id == video.id
+
+@pytest.mark.asyncio
+async def test_get_video_missing(db):
+    service = VideoService(db)
+    assert await service.get_video("missing") is None

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,2 @@
+import os
+os.environ.setdefault("SECRET_KEY", "testsecret")


### PR DESCRIPTION
## Summary
- create pytest fixtures for sqlite DB and env vars
- add unit tests for AI, video and twitch services
- mock heavy dependencies to avoid network usage
- set SECRET_KEY via sitecustomize for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859bc07dc64832695cfc303954d70e8